### PR TITLE
Update lines 64 and 65 from MyDoublyLinkedList.java to decrease lengt…

### DIFF
--- a/src/data_structures/linked_lists/doubly/MyDoublyLinkedList.java
+++ b/src/data_structures/linked_lists/doubly/MyDoublyLinkedList.java
@@ -61,6 +61,8 @@ public class MyDoublyLinkedList {
     index = wrapIndex(index);
     if(index == 0) {
       head = head.getNext();
+      head.setPrevious(null);
+      length--;
       return;
     }
 


### PR DESCRIPTION
…h and replace previous node to null

Similar behavior from SinglyLinkedList, but this time when head gets moved to the next node, the previous property still is pointing a "previous element" that shouldn't exist.